### PR TITLE
Use plumbing.Hash instead of string

### DIFF
--- a/cmd/get_commits.go
+++ b/cmd/get_commits.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	nichegit "github.com/aviator-co/niche-git"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 )
 
@@ -23,8 +24,16 @@ var (
 var getCommitsCmd = &cobra.Command{
 	Use: "get-commits",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var wantCommitHashes []plumbing.Hash
+		for _, s := range getCommitsArgs.wantCommitHashes {
+			wantCommitHashes = append(wantCommitHashes, plumbing.NewHash(s))
+		}
+		var haveCommitHashes []plumbing.Hash
+		for _, s := range getCommitsArgs.haveCommitHashes {
+			haveCommitHashes = append(haveCommitHashes, plumbing.NewHash(s))
+		}
 		client := &http.Client{Transport: &authnRoundtripper{}}
-		commits, debugInfo, fetchErr := nichegit.FetchCommits(getCommitsArgs.repoURL, client, getCommitsArgs.wantCommitHashes, getCommitsArgs.haveCommitHashes)
+		commits, debugInfo, fetchErr := nichegit.FetchCommits(getCommitsArgs.repoURL, client, wantCommitHashes, haveCommitHashes)
 		if commits == nil {
 			// Always create an empty slice for JSON output.
 			commits = []*nichegit.CommitInfo{}

--- a/cmd/get_modified_files.go
+++ b/cmd/get_modified_files.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	nichegit "github.com/aviator-co/niche-git"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +26,12 @@ var getModifiedFilesCmd = &cobra.Command{
 	Use: "get-modified-files",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := &http.Client{Transport: &authnRoundtripper{}}
-		files, debugInfo, fetchErr := nichegit.FetchModifiedFiles(getModifiedFilesArgs.repoURL, client, getModifiedFilesArgs.commitHash1, getModifiedFilesArgs.commitHash2)
+		files, debugInfo, fetchErr := nichegit.FetchModifiedFiles(
+			getModifiedFilesArgs.repoURL,
+			client,
+			plumbing.NewHash(getModifiedFilesArgs.commitHash1),
+			plumbing.NewHash(getModifiedFilesArgs.commitHash2),
+		)
 		if files == nil {
 			// Always create an empty slice for JSON output.
 			files = []string{}

--- a/commits.go
+++ b/commits.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aviator-co/niche-git/internal/fetch"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
@@ -49,7 +50,7 @@ type FetchCommitsDebugInfo struct {
 	ResponseHeaders http.Header
 }
 
-func FetchCommits(repoURL string, client *http.Client, wantCommitHashes, haveCommitHashes []string) ([]*CommitInfo, *FetchCommitsDebugInfo, error) {
+func FetchCommits(repoURL string, client *http.Client, wantCommitHashes, haveCommitHashes []plumbing.Hash) ([]*CommitInfo, *FetchCommitsDebugInfo, error) {
 	packfilebs, headers, err := fetch.FetchCommitOnlyPackfile(repoURL, client, wantCommitHashes, haveCommitHashes)
 	debugInfo := &FetchCommitsDebugInfo{
 		PackfileSize:    len(packfilebs),

--- a/internal/fetch/blob_none.go
+++ b/internal/fetch/blob_none.go
@@ -7,15 +7,16 @@ import (
 	"bytes"
 	"net/http"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/gitprotocolio"
 )
 
 // FetchBlobNonePackfile fetches a packfile from a remote repository without blobs.
-func FetchBlobNonePackfile(repoURL string, client *http.Client, oids []string) ([]byte, http.Header, error) {
+func FetchBlobNonePackfile(repoURL string, client *http.Client, oids []plumbing.Hash) ([]byte, http.Header, error) {
 	return fetchPackfile(repoURL, client, createBlobNoneFetchRequest(oids))
 }
 
-func createBlobNoneFetchRequest(oids []string) *bytes.Buffer {
+func createBlobNoneFetchRequest(oids []plumbing.Hash) *bytes.Buffer {
 	chunks := []*gitprotocolio.ProtocolV2RequestChunk{
 		{
 			Command: "fetch",
@@ -26,7 +27,7 @@ func createBlobNoneFetchRequest(oids []string) *bytes.Buffer {
 	}
 	for _, oid := range oids {
 		chunks = append(chunks, &gitprotocolio.ProtocolV2RequestChunk{
-			Argument: []byte("want " + oid),
+			Argument: []byte("want " + oid.String()),
 		})
 	}
 	chunks = append(chunks,

--- a/internal/fetch/commit_only.go
+++ b/internal/fetch/commit_only.go
@@ -7,15 +7,16 @@ import (
 	"bytes"
 	"net/http"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/gitprotocolio"
 )
 
 // FetchCommitOnlyPackfile fetches a packfile from a remote repository with only commit objects.
-func FetchCommitOnlyPackfile(repoURL string, client *http.Client, wantOids, haveOids []string) ([]byte, http.Header, error) {
+func FetchCommitOnlyPackfile(repoURL string, client *http.Client, wantOids, haveOids []plumbing.Hash) ([]byte, http.Header, error) {
 	return fetchPackfile(repoURL, client, createCommitOnlyFetchRequest(wantOids, haveOids))
 }
 
-func createCommitOnlyFetchRequest(wantOids, haveOids []string) *bytes.Buffer {
+func createCommitOnlyFetchRequest(wantOids, haveOids []plumbing.Hash) *bytes.Buffer {
 	chunks := []*gitprotocolio.ProtocolV2RequestChunk{
 		{
 			Command: "fetch",
@@ -26,12 +27,12 @@ func createCommitOnlyFetchRequest(wantOids, haveOids []string) *bytes.Buffer {
 	}
 	for _, oid := range wantOids {
 		chunks = append(chunks, &gitprotocolio.ProtocolV2RequestChunk{
-			Argument: []byte("want " + oid),
+			Argument: []byte("want " + oid.String()),
 		})
 	}
 	for _, oid := range haveOids {
 		chunks = append(chunks, &gitprotocolio.ProtocolV2RequestChunk{
-			Argument: []byte("have " + oid),
+			Argument: []byte("have " + oid.String()),
 		})
 	}
 	chunks = append(chunks,

--- a/internal/fetch/common.go
+++ b/internal/fetch/common.go
@@ -39,7 +39,7 @@ func fetchPackfile(repoURL string, client *http.Client, body *bytes.Buffer) ([]b
 			if sideband == nil {
 				return nil, headers, errors.New("unexpected non-sideband packet")
 			}
-			if pkt, ok := sideband.(gitprotocolio.BytePayloadPacket); ok {
+			if pkt, ok := sideband.(gitprotocolio.SideBandMainPacket); ok {
 				packfile.Write(pkt.Bytes())
 			}
 			continue

--- a/modified_files.go
+++ b/modified_files.go
@@ -25,8 +25,8 @@ type FetchModifiedFilesDebugInfo struct {
 }
 
 // FetchModifiedFiles returns the list of files that were modified between two commits.
-func FetchModifiedFiles(repoURL string, client *http.Client, commitHash1, commitHash2 string) ([]string, *FetchModifiedFilesDebugInfo, error) {
-	packfilebs, headers, err := fetch.FetchBlobNonePackfile(repoURL, client, []string{commitHash1, commitHash2})
+func FetchModifiedFiles(repoURL string, client *http.Client, commitHash1, commitHash2 plumbing.Hash) ([]string, *FetchModifiedFilesDebugInfo, error) {
+	packfilebs, headers, err := fetch.FetchBlobNonePackfile(repoURL, client, []plumbing.Hash{commitHash1, commitHash2})
 	debugInfo := &FetchModifiedFilesDebugInfo{
 		PackfileSize:    len(packfilebs),
 		ResponseHeaders: headers,
@@ -44,11 +44,11 @@ func FetchModifiedFiles(repoURL string, client *http.Client, commitHash1, commit
 		return nil, debugInfo, fmt.Errorf("failed to parse packfile: %v", err)
 	}
 
-	commit1, err := object.GetCommit(storage, plumbing.NewHash(commitHash1))
+	commit1, err := object.GetCommit(storage, commitHash1)
 	if err != nil {
 		return nil, debugInfo, fmt.Errorf("cannot find %q in the fetched packfile: %v", commitHash1, err)
 	}
-	commit2, err := object.GetCommit(storage, plumbing.NewHash(commitHash2))
+	commit2, err := object.GetCommit(storage, commitHash2)
 	if err != nil {
 		return nil, debugInfo, fmt.Errorf("cannot find %q in the fetched packfile: %v", commitHash2, err)
 	}


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"tree_only_three_way_merge","parentHead":"c207bf5e0e4d3097f4278a1461b64916fb7a782e","parentPull":4,"trunk":"main"}
```
-->
