### PR TITLE
Make DebugInfo as an shareable object

### DIFF
--- a/cmd/get_commits.go
+++ b/cmd/get_commits.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	nichegit "github.com/aviator-co/niche-git"
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 )
@@ -39,9 +40,8 @@ var getCommitsCmd = &cobra.Command{
 			commits = []*nichegit.CommitInfo{}
 		}
 		output := getCommitsOutput{
-			Commits:         commits,
-			ResponseHeaders: debugInfo.ResponseHeaders,
-			PackfileSize:    debugInfo.PackfileSize,
+			Commits:   commits,
+			DebugInfo: debugInfo,
 		}
 		if fetchErr != nil {
 			output.Error = fetchErr.Error()
@@ -54,10 +54,9 @@ var getCommitsCmd = &cobra.Command{
 }
 
 type getCommitsOutput struct {
-	Commits         []*nichegit.CommitInfo `json:"commits"`
-	ResponseHeaders map[string][]string    `json:"responseHeaders"`
-	PackfileSize    int                    `json:"packfileSize"`
-	Error           string                 `json:"error,omitempty"`
+	Commits   []*nichegit.CommitInfo `json:"commits"`
+	DebugInfo debug.FetchDebugInfo   `json:"debugInfo"`
+	Error     string                 `json:"error,omitempty"`
 }
 
 func init() {
@@ -65,7 +64,7 @@ func init() {
 	getCommitsCmd.Flags().StringVar(&getCommitsArgs.repoURL, "repo-url", "", "Git reposiotry URL")
 	getCommitsCmd.Flags().StringSliceVar(&getCommitsArgs.wantCommitHashes, "want-commit-hashes", nil, "Want commit hashes")
 	getCommitsCmd.Flags().StringSliceVar(&getCommitsArgs.haveCommitHashes, "have-commit-hashes", nil, "Have commit hashes")
-	getCommitsCmd.MarkFlagRequired("repo-url")
+	_ = getCommitsCmd.MarkFlagRequired("repo-url")
 
 	getCommitsCmd.Flags().StringVar(&authzHeader, "authz-header", "", "Optional authorization header")
 	getCommitsCmd.Flags().StringVar(&basicAuthzUser, "basic-authz-user", "", "Optional HTTP Basic Auth user")

--- a/cmd/get_modified_files.go
+++ b/cmd/get_modified_files.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	nichegit "github.com/aviator-co/niche-git"
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
 )
@@ -37,9 +38,8 @@ var getModifiedFilesCmd = &cobra.Command{
 			files = []string{}
 		}
 		output := getModifiedFilesOutput{
-			Files:           files,
-			ResponseHeaders: debugInfo.ResponseHeaders,
-			PackfileSize:    debugInfo.PackfileSize,
+			Files:     files,
+			DebugInfo: debugInfo,
 		}
 		sort.Strings(output.Files)
 		if fetchErr != nil {
@@ -53,10 +53,9 @@ var getModifiedFilesCmd = &cobra.Command{
 }
 
 type getModifiedFilesOutput struct {
-	Files           []string            `json:"files"`
-	ResponseHeaders map[string][]string `json:"responseHeaders"`
-	PackfileSize    int                 `json:"packfileSize"`
-	Error           string              `json:"error,omitempty"`
+	Files     []string             `json:"files"`
+	DebugInfo debug.FetchDebugInfo `json:"debugInfo"`
+	Error     string               `json:"error,omitempty"`
 }
 
 func init() {
@@ -64,9 +63,9 @@ func init() {
 	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.repoURL, "repo-url", "", "Git reposiotry URL")
 	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.commitHash1, "commit-hash1", "", "First commit hash")
 	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.commitHash2, "commit-hash2", "", "Second commit hash")
-	getModifiedFilesCmd.MarkFlagRequired("repo-url")
-	getModifiedFilesCmd.MarkFlagRequired("commit-hash1")
-	getModifiedFilesCmd.MarkFlagRequired("commit-hash2")
+	_ = getModifiedFilesCmd.MarkFlagRequired("repo-url")
+	_ = getModifiedFilesCmd.MarkFlagRequired("commit-hash1")
+	_ = getModifiedFilesCmd.MarkFlagRequired("commit-hash2")
 
 	getModifiedFilesCmd.Flags().StringVar(&authzHeader, "authz-header", "", "Optional authorization header")
 	getModifiedFilesCmd.Flags().StringVar(&basicAuthzUser, "basic-authz-user", "", "Optional HTTP Basic Auth user")

--- a/cmd/ls_refs.go
+++ b/cmd/ls_refs.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	nichegit "github.com/aviator-co/niche-git"
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/spf13/cobra"
 )
 
@@ -29,8 +30,8 @@ var lsRefsCmd = &cobra.Command{
 			refs = []*nichegit.RefInfo{}
 		}
 		output := lsRefsOutput{
-			Refs:            refs,
-			ResponseHeaders: debugInfo.ResponseHeaders,
+			Refs:      refs,
+			DebugInfo: debugInfo,
 		}
 		if fetchErr != nil {
 			output.Error = fetchErr.Error()
@@ -43,16 +44,16 @@ var lsRefsCmd = &cobra.Command{
 }
 
 type lsRefsOutput struct {
-	Refs            []*nichegit.RefInfo `json:"refs"`
-	ResponseHeaders map[string][]string `json:"responseHeaders"`
-	Error           string              `json:"error,omitempty"`
+	Refs      []*nichegit.RefInfo   `json:"refs"`
+	DebugInfo debug.LsRefsDebugInfo `json:"debugInfo"`
+	Error     string                `json:"error,omitempty"`
 }
 
 func init() {
 	rootCmd.AddCommand(lsRefsCmd)
 	lsRefsCmd.Flags().StringVar(&lsRefsArgs.repoURL, "repo-url", "", "Git reposiotry URL")
 	lsRefsCmd.Flags().StringSliceVar(&lsRefsArgs.refPrefixes, "ref-prefixes", nil, "Ref prefixes")
-	lsRefsCmd.MarkFlagRequired("repo-url")
+	_ = lsRefsCmd.MarkFlagRequired("repo-url")
 
 	lsRefsCmd.Flags().StringVar(&authzHeader, "authz-header", "", "Optional authorization header")
 	lsRefsCmd.Flags().StringVar(&basicAuthzUser, "basic-authz-user", "", "Optional HTTP Basic Auth user")

--- a/commits.go
+++ b/commits.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/aviator-co/niche-git/internal/fetch"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
@@ -42,20 +43,8 @@ type CommitInfo struct {
 	ParentHashes []string `json:"parentHashes"`
 }
 
-type FetchCommitsDebugInfo struct {
-	// PackfileSize is the size of the fetched packfile in bytes.
-	PackfileSize int
-
-	// ResponseHeaders is the headers of the HTTP response when fetching the packfile.
-	ResponseHeaders http.Header
-}
-
-func FetchCommits(repoURL string, client *http.Client, wantCommitHashes, haveCommitHashes []plumbing.Hash) ([]*CommitInfo, *FetchCommitsDebugInfo, error) {
-	packfilebs, headers, err := fetch.FetchCommitOnlyPackfile(repoURL, client, wantCommitHashes, haveCommitHashes)
-	debugInfo := &FetchCommitsDebugInfo{
-		PackfileSize:    len(packfilebs),
-		ResponseHeaders: headers,
-	}
+func FetchCommits(repoURL string, client *http.Client, wantCommitHashes, haveCommitHashes []plumbing.Hash) ([]*CommitInfo, debug.FetchDebugInfo, error) {
+	packfilebs, debugInfo, err := fetch.FetchCommitOnlyPackfile(repoURL, client, wantCommitHashes, haveCommitHashes)
 	if err != nil {
 		return nil, debugInfo, err
 	}

--- a/debug/debuginfo.go
+++ b/debug/debuginfo.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package debug
+
+type FetchDebugInfo struct {
+	// ResponseHeaders is a map of response headers.
+	ResponseHeaders map[string][]string `json:"responseHeaders"`
+	// PackfileSize is the size of the packfile in bytes.
+	PackfileSize int `json:"packfileSize"`
+}
+
+type LsRefsDebugInfo struct {
+	// ResponseHeaders is the headers of the HTTP response when fetching the packfile.
+	ResponseHeaders map[string][]string `json:"responseHeaders"`
+}

--- a/internal/fetch/blob_none.go
+++ b/internal/fetch/blob_none.go
@@ -7,12 +7,13 @@ import (
 	"bytes"
 	"net/http"
 
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/gitprotocolio"
 )
 
 // FetchBlobNonePackfile fetches a packfile from a remote repository without blobs.
-func FetchBlobNonePackfile(repoURL string, client *http.Client, oids []plumbing.Hash) ([]byte, http.Header, error) {
+func FetchBlobNonePackfile(repoURL string, client *http.Client, oids []plumbing.Hash) ([]byte, debug.FetchDebugInfo, error) {
 	return fetchPackfile(repoURL, client, createBlobNoneFetchRequest(oids))
 }
 

--- a/internal/fetch/commit_only.go
+++ b/internal/fetch/commit_only.go
@@ -7,12 +7,13 @@ import (
 	"bytes"
 	"net/http"
 
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/gitprotocolio"
 )
 
 // FetchCommitOnlyPackfile fetches a packfile from a remote repository with only commit objects.
-func FetchCommitOnlyPackfile(repoURL string, client *http.Client, wantOids, haveOids []plumbing.Hash) ([]byte, http.Header, error) {
+func FetchCommitOnlyPackfile(repoURL string, client *http.Client, wantOids, haveOids []plumbing.Hash) ([]byte, debug.FetchDebugInfo, error) {
 	return fetchPackfile(repoURL, client, createCommitOnlyFetchRequest(wantOids, haveOids))
 }
 

--- a/internal/fetch/common.go
+++ b/internal/fetch/common.go
@@ -14,13 +14,15 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/google/gitprotocolio"
 )
 
-func fetchPackfile(repoURL string, client *http.Client, body *bytes.Buffer) ([]byte, http.Header, error) {
+func fetchPackfile(repoURL string, client *http.Client, body *bytes.Buffer) ([]byte, debug.FetchDebugInfo, error) {
 	rd, headers, err := callProtocolV2(repoURL, client, body)
+	debugInfo := debug.FetchDebugInfo{ResponseHeaders: headers}
 	if err != nil {
-		return nil, headers, err
+		return nil, debugInfo, err
 	}
 	defer rd.Close()
 	v2Resp := gitprotocolio.NewProtocolV2Response(rd)
@@ -37,7 +39,7 @@ func fetchPackfile(repoURL string, client *http.Client, body *bytes.Buffer) ([]b
 		if isPackfile {
 			sideband := gitprotocolio.ParseSideBandPacket(chunk.Response)
 			if sideband == nil {
-				return nil, headers, errors.New("unexpected non-sideband packet")
+				return nil, debugInfo, errors.New("unexpected non-sideband packet")
 			}
 			if pkt, ok := sideband.(gitprotocolio.SideBandMainPacket); ok {
 				packfile.Write(pkt.Bytes())
@@ -58,9 +60,10 @@ func fetchPackfile(repoURL string, client *http.Client, body *bytes.Buffer) ([]b
 		}
 	}
 	if err := v2Resp.Err(); err != nil {
-		return nil, headers, fmt.Errorf("failed to parse the protov2 resposne: %v", err)
+		return nil, debugInfo, fmt.Errorf("failed to parse the protov2 resposne: %v", err)
 	}
-	return packfile.Bytes(), headers, nil
+	debugInfo.PackfileSize = packfile.Len()
+	return packfile.Bytes(), debugInfo, nil
 }
 
 func callProtocolV2(repoURL string, client *http.Client, body *bytes.Buffer) (io.ReadCloser, http.Header, error) {

--- a/ls_refs.go
+++ b/ls_refs.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/aviator-co/niche-git/internal/fetch"
 )
 
@@ -27,16 +28,9 @@ type RefInfo struct {
 	SymbolicTarget string `json:"symbolicTarget,omitempty"`
 }
 
-type LsRefsDebugInfo struct {
-	// ResponseHeaders is the headers of the HTTP response when fetching the packfile.
-	ResponseHeaders http.Header
-}
-
-func LsRefs(repoURL string, client *http.Client, refPrefixes []string) ([]*RefInfo, *LsRefsDebugInfo, error) {
+func LsRefs(repoURL string, client *http.Client, refPrefixes []string) ([]*RefInfo, debug.LsRefsDebugInfo, error) {
 	rawRefData, headers, err := fetch.LsRefs(repoURL, client, refPrefixes)
-	debugInfo := &LsRefsDebugInfo{
-		ResponseHeaders: headers,
-	}
+	debugInfo := debug.LsRefsDebugInfo{ResponseHeaders: headers}
 	if err != nil {
 		return nil, debugInfo, err
 	}

--- a/modified_files.go
+++ b/modified_files.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/aviator-co/niche-git/debug"
 	"github.com/aviator-co/niche-git/internal/diff"
 	"github.com/aviator-co/niche-git/internal/fetch"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -16,21 +17,9 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 )
 
-type FetchModifiedFilesDebugInfo struct {
-	// PackfileSize is the size of the fetched packfile in bytes.
-	PackfileSize int
-
-	// ResponseHeaders is the headers of the HTTP response when fetching the packfile.
-	ResponseHeaders http.Header
-}
-
 // FetchModifiedFiles returns the list of files that were modified between two commits.
-func FetchModifiedFiles(repoURL string, client *http.Client, commitHash1, commitHash2 plumbing.Hash) ([]string, *FetchModifiedFilesDebugInfo, error) {
-	packfilebs, headers, err := fetch.FetchBlobNonePackfile(repoURL, client, []plumbing.Hash{commitHash1, commitHash2})
-	debugInfo := &FetchModifiedFilesDebugInfo{
-		PackfileSize:    len(packfilebs),
-		ResponseHeaders: headers,
-	}
+func FetchModifiedFiles(repoURL string, client *http.Client, commitHash1, commitHash2 plumbing.Hash) ([]string, debug.FetchDebugInfo, error) {
+	packfilebs, debugInfo, err := fetch.FetchBlobNonePackfile(repoURL, client, []plumbing.Hash{commitHash1, commitHash2})
 	if err != nil {
 		return nil, debugInfo, err
 	}


### PR DESCRIPTION
These are used commonly in multiple places.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"use_hash","parentHead":"c7bed885c2e3d79886900fe1d80fcc0a6a620c25","parentPull":5,"trunk":"main"}
```
-->
