### PR TITLE
Specify JSON struct tag for properly naming fields

### DIFF
--- a/debug/debuginfo.go
+++ b/debug/debuginfo.go
@@ -17,9 +17,9 @@ type LsRefsDebugInfo struct {
 
 type PushCommandStatus struct {
 	// Name is the name of the reference.
-	Name string
+	Name string `json:"name"`
 	// Status is the status of the command.
-	Status string
+	Status string `json:"status"`
 }
 
 type PushDebugInfo struct {


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
