### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go run cmd/niche-git/main.go get-modified-files \
     --repo-url https://github.com/draftcode/some-private-repo \
     --commit-hash1 998122b45e63b2999d57a1af9e74761c0524e932 \
     --commit-hash2 f27a58920f7319cc7b62e55cf3095d1ee2ab1dde \
-    --basic-authz-user x-acess-token \
+    --basic-authz-user x-access-token \
     --basic-authz-password "$(gh auth token)"
 ```
 

--- a/cmd/get_commits.go
+++ b/cmd/get_commits.go
@@ -61,7 +61,7 @@ type getCommitsOutput struct {
 
 func init() {
 	rootCmd.AddCommand(getCommitsCmd)
-	getCommitsCmd.Flags().StringVar(&getCommitsArgs.repoURL, "repo-url", "", "Git reposiotry URL")
+	getCommitsCmd.Flags().StringVar(&getCommitsArgs.repoURL, "repo-url", "", "Git repository URL")
 	getCommitsCmd.Flags().StringSliceVar(&getCommitsArgs.wantCommitHashes, "want-commit-hashes", nil, "Want commit hashes")
 	getCommitsCmd.Flags().StringSliceVar(&getCommitsArgs.haveCommitHashes, "have-commit-hashes", nil, "Have commit hashes")
 	_ = getCommitsCmd.MarkFlagRequired("repo-url")

--- a/cmd/get_modified_files.go
+++ b/cmd/get_modified_files.go
@@ -60,7 +60,7 @@ type getModifiedFilesOutput struct {
 
 func init() {
 	rootCmd.AddCommand(getModifiedFilesCmd)
-	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.repoURL, "repo-url", "", "Git reposiotry URL")
+	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.repoURL, "repo-url", "", "Git repository URL")
 	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.commitHash1, "commit-hash1", "", "First commit hash")
 	getModifiedFilesCmd.Flags().StringVar(&getModifiedFilesArgs.commitHash2, "commit-hash2", "", "Second commit hash")
 	_ = getModifiedFilesCmd.MarkFlagRequired("repo-url")

--- a/cmd/ls_refs.go
+++ b/cmd/ls_refs.go
@@ -51,7 +51,7 @@ type lsRefsOutput struct {
 
 func init() {
 	rootCmd.AddCommand(lsRefsCmd)
-	lsRefsCmd.Flags().StringVar(&lsRefsArgs.repoURL, "repo-url", "", "Git reposiotry URL")
+	lsRefsCmd.Flags().StringVar(&lsRefsArgs.repoURL, "repo-url", "", "Git repository URL")
 	lsRefsCmd.Flags().StringSliceVar(&lsRefsArgs.refPrefixes, "ref-prefixes", nil, "Ref prefixes")
 	_ = lsRefsCmd.MarkFlagRequired("repo-url")
 

--- a/cmd/squash_cherry_pick.go
+++ b/cmd/squash_cherry_pick.go
@@ -144,7 +144,7 @@ type squashCherryPickOutput struct {
 
 func init() {
 	rootCmd.AddCommand(squashCherryPick)
-	squashCherryPick.Flags().StringVar(&squashCherryPickArgs.repoURL, "repo-url", "", "Git reposiotry URL")
+	squashCherryPick.Flags().StringVar(&squashCherryPickArgs.repoURL, "repo-url", "", "Git repository URL")
 	squashCherryPick.Flags().StringVar(&squashCherryPickArgs.cherryPickFrom, "cherry-pick-from", "", "Commit hash where cherry-pick from")
 	squashCherryPick.Flags().StringVar(&squashCherryPickArgs.cherryPickTo, "cherry-pick-to", "", "Commit hash where cherry-pick to")
 	squashCherryPick.Flags().StringVar(&squashCherryPickArgs.cherryPickBase, "cherry-pick-base", "", "The merge base of the cherry-pick from. The changes from this commit to cherry-pick-from will be applied to cherry-pick-to.")


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
