### PR TITLE
Add a command to get modified files with regexp matches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,3 +1,6 @@
+# Copyright 2024 Aviator Technologies, Inc.
+# SPDX-License-Identifier: MIT
+
 name: Go
 
 concurrency:

--- a/cmd/get_modified_files_regexp_matches.go
+++ b/cmd/get_modified_files_regexp_matches.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"net/http"
+	"regexp"
+
+	nichegit "github.com/aviator-co/niche-git"
+	"github.com/aviator-co/niche-git/debug"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+type GetModifiedFilesPattern struct {
+	FilePathPatterns   []string `json:"filePathPatterns"`
+	FileContentPattern string   `json:"fileContentPattern,omitempty"`
+}
+
+type GetModifiedFilesRegexpMatchesArgs struct {
+	RepoURL     string                             `json:"repoURL"`
+	CommitHash1 string                             `json:"commitHash1"`
+	CommitHash2 string                             `json:"commitHash2"`
+	Patterns    map[string]GetModifiedFilesPattern `json:"patterns"`
+}
+
+type getModifiedFilesRegexpMatchesOutput struct {
+	Files              []*nichegit.ModifiedFile `json:"files"`
+	FetchDebugInfo     *debug.FetchDebugInfo    `json:"fetchDebugInfo"`
+	BlobFetchDebugInfo *debug.FetchDebugInfo    `json:"blobFetchDebugInfo"`
+	Error              string                   `json:"error,omitempty"`
+}
+
+func GetModifiedFilesRegexpMatches(args GetModifiedFilesRegexpMatchesArgs) *getModifiedFilesRegexpMatchesOutput {
+	patterns := make(map[string]nichegit.ModifiedFilePattern)
+	for key, value := range args.Patterns {
+		v := nichegit.ModifiedFilePattern{
+			FilePathPattern: value.FilePathPatterns,
+		}
+		if value.FileContentPattern != "" {
+			pattern, err := regexp.Compile(value.FileContentPattern)
+			if err != nil {
+				return &getModifiedFilesRegexpMatchesOutput{Error: err.Error()}
+			}
+			v.FileContentPattern = pattern
+		}
+		patterns[key] = v
+	}
+
+	client := &http.Client{Transport: &authnRoundtripper{}}
+	files, fetchDebugInfo, blobFetchDebugInfo, err := nichegit.FetchModifiedFilesWithRegexpMatch(
+		args.RepoURL,
+		client,
+		plumbing.NewHash(args.CommitHash1),
+		plumbing.NewHash(args.CommitHash2),
+		patterns,
+	)
+	output := &getModifiedFilesRegexpMatchesOutput{
+		Files:              files,
+		FetchDebugInfo:     &fetchDebugInfo,
+		BlobFetchDebugInfo: blobFetchDebugInfo,
+	}
+	if err != nil {
+		output.Error = err.Error()
+	}
+	return output
+}

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	pipeArg struct {
+		command    string
+		inputFile  string
+		outputFile string
+	}
+)
+
+var pipeCmd = &cobra.Command{
+	Use: "pipe",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var in io.Reader
+		if pipeArg.inputFile == "-" {
+			in = os.Stdin
+		} else {
+			file, err := os.Open(pipeArg.inputFile)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			in = file
+		}
+		dec := json.NewDecoder(in)
+
+		switch pipeArg.command {
+		case "get-modified-files-regexp-matches":
+			input := GetModifiedFilesRegexpMatchesArgs{}
+			if err := dec.Decode(&input); err != nil {
+				return err
+			}
+			output := GetModifiedFilesRegexpMatches(input)
+			return writeJSON(pipeArg.outputFile, output)
+		}
+		return fmt.Errorf("unknown command: %s", pipeArg.command)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pipeCmd)
+
+	pipeCmd.Flags().StringVar(&authzHeader, "authz-header", "", "Optional authorization header")
+	pipeCmd.Flags().StringVar(&basicAuthzUser, "basic-authz-user", "", "Optional HTTP Basic Auth user")
+	pipeCmd.Flags().StringVar(&basicAuthzPassword, "basic-authz-password", "", "Optional HTTP Basic Auth password")
+
+	pipeCmd.Flags().StringVar(&pipeArg.command, "command", "", "Command to execute")
+	pipeCmd.Flags().StringVar(&pipeArg.inputFile, "input-file", "-", "Optional input file path. '-', which is the default, means stdin")
+	pipeCmd.Flags().StringVar(&pipeArg.outputFile, "output-file", "-", "Optional output file path. '-', which is the default, means stdout")
+	_ = pipeCmd.MarkFlagRequired("command")
+}

--- a/e2e_tests/.gitignore
+++ b/e2e_tests/.gitignore
@@ -1,1 +1,1 @@
-/niche-git
+niche-git

--- a/e2e_tests/helper_git.go
+++ b/e2e_tests/helper_git.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
 package e2e_tests
 
 import (
@@ -73,7 +76,9 @@ func (r *GitTestRepo) AddFile(t *testing.T, fp string) {
 
 func (r *GitTestRepo) CreateFile(t *testing.T, filename string, body string) string {
 	fp := filepath.Join(r.RepoDir, filename)
-	err := os.WriteFile(fp, []byte(body), 0644)
+	err := os.MkdirAll(filepath.Dir(fp), 0755)
+	require.NoError(t, err, "failed to create dirs: %s", filename)
+	err = os.WriteFile(fp, []byte(body), 0644)
 	require.NoError(t, err, "failed to write file: %s", filename)
 	return fp
 }

--- a/e2e_tests/helper_niche_git.go
+++ b/e2e_tests/helper_niche_git.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
 package e2e_tests
 
 import (
@@ -35,7 +38,7 @@ type NicheGitOutput struct {
 	Stderr   string
 }
 
-func cmd(t *testing.T, exe string, args ...string) NicheGitOutput {
+func cmdInternal(t *testing.T, exe string, args ...string) NicheGitOutput {
 	cmd := exec.Command(exe, args...)
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -69,7 +72,7 @@ func cmd(t *testing.T, exe string, args ...string) NicheGitOutput {
 }
 
 func NicheGit(t *testing.T, args ...string) NicheGitOutput {
-	return cmd(t, nicheGitCmdPath, args...)
+	return cmdInternal(t, nicheGitCmdPath, args...)
 }
 
 func RequireNicheGit(t *testing.T, args ...string) NicheGitOutput {

--- a/e2e_tests/modified_files_regexp_matches_test.go
+++ b/e2e_tests/modified_files_regexp_matches_test.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package e2e_tests
+
+import (
+	"testing"
+
+	nichegit "github.com/aviator-co/niche-git"
+	"github.com/aviator-co/niche-git/cmd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModifiedFilesRegexpMatches(t *testing.T) {
+	repo := NewTempRepo(t)
+
+	repo.CommitFile(t, "tests/com/example/ServiceTest.java", "")
+	baseHash := repo.CommitFile(t, "tests/com/example/E2ETest.java", `
+	@Ignore
+	public void test1() { }
+	@Ignore
+	public void test2() { }
+	@Ignore
+	public void test3() { }
+	`)
+
+	repo.CommitFile(t, "tests/com/example/ServiceTest.java", "random change")
+	repo.CommitFile(t, "tests/com/example/E2ETest.java", `
+	@Ignore
+	public void test1() { }
+	@Ignore
+	public void test2() { }
+	@Ignore
+	public void test3() { }
+	@Ignore
+	public void test4() { }
+	@Ignore
+	public void test5() { }
+	`)
+	targetHash := repo.CommitFile(t, "src/migrations/add_table_20240822.sql", "")
+
+	output := cmd.GetModifiedFilesRegexpMatches(
+		cmd.GetModifiedFilesRegexpMatchesArgs{
+			RepoURL:     "file://" + repo.RepoDir,
+			CommitHash1: baseHash.String(),
+			CommitHash2: targetHash.String(),
+			Patterns: map[string]cmd.GetModifiedFilesPattern{
+				"ignore_test": {
+					FilePathPatterns:   []string{"**/*.java"},
+					FileContentPattern: `@Ignore`,
+				},
+				"database_migration": {
+					FilePathPatterns: []string{"src/migrations/*.sql"},
+				},
+			},
+		},
+	)
+	require.Equal(t, "", output.Error)
+	require.Equal(t, []*nichegit.ModifiedFile{
+		{
+			Path:   "src/migrations/add_table_20240822.sql",
+			Status: nichegit.ModificationStatusAdded,
+			Matches: map[string]*nichegit.ModifiedFilePatternMatch{
+				"database_migration": {
+					Before: 0,
+					After:  1,
+				},
+			},
+		},
+		{
+			Path:   "tests/com/example/E2ETest.java",
+			Status: nichegit.ModificationStatusModified,
+			Matches: map[string]*nichegit.ModifiedFilePatternMatch{
+				"ignore_test": {
+					Before: 3,
+					After:  5,
+				},
+			},
+		},
+		{
+			Path:   "tests/com/example/ServiceTest.java",
+			Status: nichegit.ModificationStatusModified,
+		},
+	}, output.Files)
+}

--- a/e2e_tests/squash_cherry_pick_test.go
+++ b/e2e_tests/squash_cherry_pick_test.go
@@ -1,3 +1,6 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
 package e2e_tests
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aviator-co/niche-git
 go 1.22.1
 
 require (
+	github.com/bmatcuk/doublestar v1.3.4
 	github.com/epiclabs-io/diff3 v0.0.0-20240325112732-ba77e92bf0e4
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/gitprotocolio v0.0.0-20210704173409-b5a56823ae52

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.4.0 h1:BV7h5MgrktNzytKmWjpOtdYrf0lkkbF8YMlBGPhJQrY=

--- a/modified_files_regexp_matches.go
+++ b/modified_files_regexp_matches.go
@@ -1,0 +1,229 @@
+// Copyright 2024 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package nichegit
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+
+	"github.com/aviator-co/niche-git/debug"
+	"github.com/aviator-co/niche-git/internal/diff"
+	"github.com/aviator-co/niche-git/internal/fetch"
+	"github.com/bmatcuk/doublestar"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/packfile"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+type ModifiedFilePattern struct {
+	// FilePathPattern is a list of doublestar matching patterns for the file paths.
+	FilePathPattern []string
+	// FileContentPattern is an optional regular expression pattern for the file content.
+	FileContentPattern *regexp.Regexp
+}
+
+type ModificationStatus string
+
+const (
+	ModificationStatusAdded    ModificationStatus = "ADDED"
+	ModificationStatusDeleted  ModificationStatus = "DELETED"
+	ModificationStatusModified ModificationStatus = "MODIFIED"
+)
+
+type ModifiedFilePatternMatch struct {
+	Before int `json:"before"`
+	After  int `json:"after"`
+}
+
+type ModifiedFile struct {
+	Path    string                               `json:"path"`
+	Status  ModificationStatus                   `json:"status"`
+	Matches map[string]*ModifiedFilePatternMatch `json:"matches,omitempty"`
+}
+
+func FetchModifiedFilesWithRegexpMatch(
+	repoURL string,
+	client *http.Client,
+	commitHash1, commitHash2 plumbing.Hash,
+	patterns map[string]ModifiedFilePattern,
+) ([]*ModifiedFile, debug.FetchDebugInfo, *debug.FetchDebugInfo, error) {
+	packfilebs, fetchDebugInfo, err := fetch.FetchBlobNonePackfile(repoURL, client, []plumbing.Hash{commitHash1, commitHash2})
+	if err != nil {
+		return nil, fetchDebugInfo, nil, err
+	}
+
+	storage := memory.NewStorage()
+	parser, err := packfile.NewParserWithStorage(packfile.NewScanner(bytes.NewReader(packfilebs)), storage)
+	if err != nil {
+		return nil, fetchDebugInfo, nil, fmt.Errorf("failed to parse packfile: %v", err)
+	}
+	if _, err := parser.Parse(); err != nil {
+		return nil, fetchDebugInfo, nil, fmt.Errorf("failed to parse packfile: %v", err)
+	}
+
+	tree1, err := getTreeFromCommit(storage, commitHash1)
+	if err != nil {
+		return nil, fetchDebugInfo, nil, err
+	}
+	tree2, err := getTreeFromCommit(storage, commitHash2)
+	if err != nil {
+		return nil, fetchDebugInfo, nil, err
+	}
+
+	modified, err := diff.DiffTree(storage, tree1, tree2)
+	if err != nil {
+		return nil, fetchDebugInfo, nil, fmt.Errorf("failed to take file diffs: %v", err)
+	}
+
+	packfilebs, fetchBlobDebugInfo, err := fetch.FetchBlobPackfile(repoURL, client, getBlobHashes(modified))
+	blobFetchDebugInfo := &fetchBlobDebugInfo
+	if err != nil {
+		return nil, fetchDebugInfo, blobFetchDebugInfo, err
+	}
+	parser, err = packfile.NewParserWithStorage(packfile.NewScanner(bytes.NewReader(packfilebs)), storage)
+	if err != nil {
+		return nil, fetchDebugInfo, blobFetchDebugInfo, fmt.Errorf("failed to parse packfile: %v", err)
+	}
+	if _, err := parser.Parse(); err != nil {
+		return nil, fetchDebugInfo, blobFetchDebugInfo, fmt.Errorf("failed to parse packfile: %v", err)
+	}
+
+	var ret []*ModifiedFile
+	for path, hashes := range modified {
+		m, err := matchWithPattern(storage, patterns, path, hashes)
+		if err != nil {
+			return nil, fetchDebugInfo, blobFetchDebugInfo, err
+		}
+		ret = append(ret, m)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Path < ret[j].Path
+	})
+	return ret, fetchDebugInfo, blobFetchDebugInfo, nil
+}
+
+func getBlobHashes(modified map[string]diff.BlobHashes) []plumbing.Hash {
+	m := map[plumbing.Hash]struct{}{}
+	for _, hashes := range modified {
+		if !hashes.BlobHash1.IsZero() {
+			m[hashes.BlobHash1] = struct{}{}
+		}
+		if !hashes.BlobHash2.IsZero() {
+			m[hashes.BlobHash2] = struct{}{}
+		}
+	}
+	hashes := make([]plumbing.Hash, 0, len(m))
+	for hash := range m {
+		hashes = append(hashes, hash)
+	}
+	return hashes
+}
+
+func matchWithPattern(storage *memory.Storage, patterns map[string]ModifiedFilePattern, path string, blobs diff.BlobHashes) (*ModifiedFile, error) {
+	status := ModificationStatusModified
+	var content1 []byte
+	var content2 []byte
+	if blobs.BlobHash1.IsZero() {
+		// File is added.
+		status = ModificationStatusAdded
+	} else {
+		var err error
+		content1, err = getBlobContent(storage, blobs.BlobHash1)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read the file %q: %v", path, err)
+		}
+	}
+	if blobs.BlobHash2.IsZero() {
+		// File is deleted.
+		status = ModificationStatusDeleted
+	} else {
+		var err error
+		content2, err = getBlobContent(storage, blobs.BlobHash2)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read the file %q: %v", path, err)
+		}
+	}
+	matches := map[string]*ModifiedFilePatternMatch{}
+	for name, pattern := range patterns {
+		match, err := matchPattern(pattern, path, status, content1, content2)
+		if err != nil {
+			return nil, fmt.Errorf("cannot match the pattern %q: %v", name, err)
+		}
+		if match != nil {
+			matches[name] = match
+		}
+	}
+	ret := &ModifiedFile{
+		Path:   path,
+		Status: status,
+	}
+	if len(matches) > 0 {
+		ret.Matches = matches
+	}
+	return ret, nil
+}
+
+func getBlobContent(storage *memory.Storage, hash plumbing.Hash) ([]byte, error) {
+	blob, err := storage.EncodedObject(plumbing.BlobObject, hash)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open the hash %q: %v", hash.String(), err)
+	}
+	rd, err := blob.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("cannot open the blob: %v", err)
+	}
+	defer rd.Close()
+	bs, err := io.ReadAll(rd)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read the blob: %v", err)
+	}
+	return bs, nil
+}
+
+func matchPattern(pattern ModifiedFilePattern, path string, status ModificationStatus, content1, content2 []byte) (*ModifiedFilePatternMatch, error) {
+	if matched, err := matchPath(pattern.FilePathPattern, path); err != nil {
+		return nil, err
+	} else if !matched {
+		return nil, nil
+	}
+	if pattern.FileContentPattern == nil {
+		switch status {
+		case ModificationStatusAdded:
+			return &ModifiedFilePatternMatch{Before: 0, After: 1}, nil
+		case ModificationStatusDeleted:
+			return &ModifiedFilePatternMatch{Before: 1, After: 0}, nil
+		case ModificationStatusModified:
+			return &ModifiedFilePatternMatch{Before: 1, After: 1}, nil
+		}
+	}
+	before := len(pattern.FileContentPattern.FindAll(content1, -1))
+	after := len(pattern.FileContentPattern.FindAll(content2, -1))
+	println(before, after)
+	if before == 0 && after == 0 {
+		// No match.
+		return nil, nil
+	}
+	return &ModifiedFilePatternMatch{Before: before, After: after}, nil
+}
+
+func matchPath(doublestartPatterns []string, path string) (bool, error) {
+	for i := len(doublestartPatterns) - 1; i >= 0; i-- {
+		pat := doublestartPatterns[i]
+		resultIfMatched := true
+		if pat[0] == '!' {
+			resultIfMatched = false
+			pat = pat[1:]
+		}
+		if matched, err := doublestar.Match(pat, path); err != nil {
+			return false, err
+		} else if matched {
+			return resultIfMatched, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
