### PR TITLE
Add content-type and accept headers

### DIFF
--- a/internal/fetch/common.go
+++ b/internal/fetch/common.go
@@ -85,6 +85,8 @@ func callProtocolV2HTTP(repoURL string, client *http.Client, body *bytes.Buffer)
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	req.Header.Set("Accept", "application/x-git-upload-pack-result")
 	req.Header.Set("Git-Protocol", "version=2")
 	if client == nil {
 		client = http.DefaultClient


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
