### PR TITLE
Add a new command to update refs

### DIFF
--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -57,6 +57,13 @@ var pipeCmd = &cobra.Command{
 			}
 			output := SquashPush(input)
 			return writeJSON(pipeArg.outputFile, output)
+		case "update-refs":
+			input := nichegit.UpdateRefsArgs{}
+			if err := dec.Decode(&input); err != nil {
+				return err
+			}
+			output := UpdateRefs(input)
+			return writeJSON(pipeArg.outputFile, output)
 		}
 
 		return fmt.Errorf("unknown command: %s", pipeArg.command)

--- a/cmd/update_refs.go
+++ b/cmd/update_refs.go
@@ -1,0 +1,15 @@
+// Copyright 2025 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	"net/http"
+
+	nichegit "github.com/aviator-co/niche-git"
+)
+
+func UpdateRefs(args nichegit.UpdateRefsArgs) nichegit.UpdateRefsOutput {
+	client := &http.Client{Transport: &authnRoundtripper{}}
+	return nichegit.UpdateRefs(client, args)
+}

--- a/e2e_tests/update_refs_test.go
+++ b/e2e_tests/update_refs_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package e2e_tests
+
+import (
+	"testing"
+
+	nichegit "github.com/aviator-co/niche-git"
+	"github.com/aviator-co/niche-git/cmd"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateRefs(t *testing.T) {
+	repo := NewTempRepo(t)
+
+	baseHash := repo.CommitFile(t, "file1", "test")
+	output := cmd.UpdateRefs(
+		nichegit.UpdateRefsArgs{
+			RepoURL: "file://" + repo.RepoDir,
+			RefUpdateCommands: []nichegit.RefUpdateCommand{
+				{
+					RefName: "refs/heads/random",
+					OldHash: plumbing.ZeroHash.String(),
+					NewHash: baseHash.String(),
+				},
+			},
+		},
+	)
+	require.Empty(t, output.Error)
+	require.Contains(t, repo.Git(t, "branch"), "random")
+}
+
+func TestUpdateRefs_Conflict_Atomic(t *testing.T) {
+	repo := NewTempRepo(t)
+
+	baseHash := repo.CommitFile(t, "file1", "test")
+	repo.Git(t, "switch", "--detach", "HEAD")
+	output := cmd.UpdateRefs(
+		nichegit.UpdateRefsArgs{
+			RepoURL: "file://" + repo.RepoDir,
+			RefUpdateCommands: []nichegit.RefUpdateCommand{
+				{
+					RefName: "refs/heads/main",
+					OldHash: plumbing.ZeroHash.String(),
+					NewHash: baseHash.String(),
+				},
+				{
+					RefName: "refs/heads/random",
+					OldHash: plumbing.ZeroHash.String(),
+					NewHash: baseHash.String(),
+				},
+			},
+		},
+	)
+	require.Contains(t, output.Error, "atomic transaction failed")
+	require.NotContains(t, repo.Git(t, "branch"), "random")
+}
+
+func TestUpdateRefs_PreconditionMismatch(t *testing.T) {
+	repo := NewTempRepo(t)
+
+	baseHash := repo.CommitFile(t, "file1", "test")
+	repo.Git(t, "checkout", "-b", "test")
+	anotherHash := repo.CommitFile(t, "file2", "test")
+
+	output := cmd.UpdateRefs(
+		nichegit.UpdateRefsArgs{
+			RepoURL: "file://" + repo.RepoDir,
+			RefUpdateCommands: []nichegit.RefUpdateCommand{
+				{
+					RefName: "refs/heads/main",
+					// main is on baseHash. So this should fail the
+					// precondition.
+					OldHash: anotherHash.String(),
+					NewHash: baseHash.String(),
+				},
+			},
+		},
+	)
+	require.Contains(t, output.Error, "atomic transaction failed")
+}

--- a/internal/push/push.go
+++ b/internal/push/push.go
@@ -61,6 +61,7 @@ func Push(repoURL string, client *http.Client, packfile *bytes.Buffer, refUpdate
 	}
 
 	req := packp.NewReferenceUpdateRequestFromCapabilities(advRef.Capabilities)
+	_ = req.Capabilities.Add("atomic")
 	if packfile != nil {
 		req.Packfile = io.NopCloser(packfile)
 	}

--- a/update_refs.go
+++ b/update_refs.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Aviator Technologies, Inc.
+// SPDX-License-Identifier: MIT
+
+package nichegit
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/aviator-co/niche-git/debug"
+	"github.com/aviator-co/niche-git/internal/push"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/packfile"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+type RefUpdateCommand struct {
+	// RefName is a reference name to update (e.g. "refs/heads/main").
+	RefName string `json:"refName"`
+	// OldHash is a hash of the reference before the update.
+	//
+	// There is a difference between zero hash and empty string:
+	//
+	// * If this is a zero hash, it means that the reference should be newly created (it should
+	//   not exist.
+	// * If this is an empty string, it means that the reference is updated unconditionally
+	//   (force update).
+	//
+	// Note that, at the git-transport level, everything is a force update. The client should
+	// check if the reference being updated is fast-forwardable if they want such behavior.
+	OldHash string `json:"oldHash"`
+	// NewHash is a hash of the reference after the update.
+	NewHash string `json:"newHash"`
+}
+
+type UpdateRefsArgs struct {
+	RepoURL           string             `json:"repoURL"`
+	RefUpdateCommands []RefUpdateCommand `json:"refUpdateCommands"`
+}
+
+type UpdateRefsOutput struct {
+	PushDebugInfo *debug.PushDebugInfo `json:"pushDebugInfo"`
+	Error         string               `json:"error,omitempty"`
+}
+
+func UpdateRefs(client *http.Client, args UpdateRefsArgs) UpdateRefsOutput {
+	var refUpdates []push.RefUpdate
+	for _, refUpdateCommand := range args.RefUpdateCommands {
+		ru := push.RefUpdate{
+			Name:    plumbing.ReferenceName(refUpdateCommand.RefName),
+			OldHash: nil,
+			NewHash: plumbing.NewHash(refUpdateCommand.NewHash),
+		}
+		if refUpdateCommand.OldHash != "" {
+			h := plumbing.NewHash(refUpdateCommand.OldHash)
+			ru.OldHash = &h
+		}
+		refUpdates = append(refUpdates, ru)
+	}
+
+	// Need to create an empty packfile to push.
+	var buf bytes.Buffer
+	packEncoder := packfile.NewEncoder(&buf, memory.NewStorage(), false)
+	if _, err := packEncoder.Encode(nil, 0); err != nil {
+		return UpdateRefsOutput{Error: err.Error()}
+	}
+
+	var ret UpdateRefsOutput
+	pushDebugInfo, err := push.Push(args.RepoURL, client, &buf, refUpdates)
+	ret.PushDebugInfo = &pushDebugInfo
+	if err != nil {
+		ret.Error = err.Error()
+	}
+	return ret
+}


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
