### PR TITLE
fix linear rebase failing on prefix-colliding branch names

### DIFF
--- a/e2e_tests/linear_rebase_test.go
+++ b/e2e_tests/linear_rebase_test.go
@@ -83,6 +83,49 @@ func TestLinearRebase(t *testing.T) {
 	require.Equal(t, expected, output.LinearRebaseResults, "Expected linear rebase results to match")
 }
 
+func TestLinearRebase_RefPrefixCollision(t *testing.T) {
+	repo := NewTempRepo(t)
+
+	baseHash := repo.CommitFile(t, "file", "1")
+	repo.Git(t, "checkout", "-b", "branch")
+	repo.CommitFile(t, "file", "2")
+	// Sibling branch whose name has "branch" as a string prefix. ls-refs matches by
+	// ref-prefix, so requesting "refs/heads/branch" also returns "refs/heads/branch-extra".
+	repo.Git(t, "checkout", "-b", "branch-extra")
+	repo.CommitFile(t, "other", "other")
+	repo.Git(t, "switch", "main")
+	mainHash := repo.CommitFile(t, "unrelated", "unrelated")
+
+	output := nichegit.LinearRebase(
+		t.Context(),
+		http.DefaultClient,
+		nichegit.LinearRebaseArgs{
+			RepoURL:           "file://" + repo.RepoDir,
+			DestinationCommit: mainHash.String(),
+			Refs: []nichegit.LinearRebaseArgRef{
+				{
+					Ref:        "refs/heads/branch",
+					BaseCommit: baseHash.String(),
+				},
+			},
+		},
+	)
+	require.Empty(t, output.Error, "ref-prefix collision should not fail linear rebase")
+
+	repo.Git(t, "switch", "branch")
+	branchHash := strings.TrimSpace(repo.Git(t, "rev-parse", "HEAD"))
+	require.Equal(t, "2", repo.ReadFile(t, "file"), "Branch should have the latest commit after rebase")
+	require.Equal(t, "unrelated", repo.ReadFile(t, "unrelated"), "Branch should be rebased onto the destination")
+
+	expected := []*nichegit.LinearRebaseResult{
+		{
+			Ref:        "refs/heads/branch",
+			CommitHash: branchHash,
+		},
+	}
+	require.Equal(t, expected, output.LinearRebaseResults, "Expected only the exact ref to be rebased")
+}
+
 func TestLinearRebase_NewCommits(t *testing.T) {
 	repo := NewTempRepo(t)
 

--- a/linear_rebase.go
+++ b/linear_rebase.go
@@ -66,8 +66,18 @@ func LinearRebase(ctx context.Context, client *http.Client, args LinearRebaseArg
 	if err != nil {
 		return LinearRebaseOutput{LsRefsDebugInfo: &lsRefsDebugInfo, Error: err.Error()}
 	}
+	// ls-refs filters by ref-prefix (the only filter git protocol v2 offers), so a
+	// requested ref name that is a string prefix of another branch (e.g. "foo" also
+	// matches "foo-bar") brings back refs we didn't ask for. Keep only exact matches.
+	requestedRefs := make(map[string]bool, len(args.Refs))
+	for _, ref := range args.Refs {
+		requestedRefs[ref.Ref] = true
+	}
 	refMap := make(map[string]*linearRebaseArgRef)
 	for _, ref := range refs {
+		if !requestedRefs[ref.Name] {
+			continue
+		}
 		refMap[ref.Name] = &linearRebaseArgRef{
 			ref:        ref.Name,
 			baseCommit: refBaseCommits[ref.Name],


### PR DESCRIPTION
ls-refs filters by ref-prefix, so a branch name that's a string prefix of another branch made linear rebase fail the ref-count check.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
